### PR TITLE
Add missing selectors and replace properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ras-idosell-front",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "src/index.ts",
   "scripts": {
     "eslint": "eslint --ext .js,.ts ./src",

--- a/src/consts/replaceMap/basketPageHotSpot.ts
+++ b/src/consts/replaceMap/basketPageHotSpot.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/mainPageHotSpotOne.ts
+++ b/src/consts/replaceMap/mainPageHotSpotOne.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/mainPageHotSpotThree.ts
+++ b/src/consts/replaceMap/mainPageHotSpotThree.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/mainPageHotSpotTwo.ts
+++ b/src/consts/replaceMap/mainPageHotSpotTwo.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/mainPageHotspotFour.ts
+++ b/src/consts/replaceMap/mainPageHotspotFour.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsDetailsAssociatedFour.ts
+++ b/src/consts/replaceMap/productsDetailsAssociatedFour.ts
@@ -30,6 +30,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -145,7 +150,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsDetailsAssociatedOne.ts
+++ b/src/consts/replaceMap/productsDetailsAssociatedOne.ts
@@ -30,6 +30,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -145,7 +150,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsDetailsAssociatedThree.ts
+++ b/src/consts/replaceMap/productsDetailsAssociatedThree.ts
@@ -30,6 +30,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -145,7 +150,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsDetailsAssociatedTwo.ts
+++ b/src/consts/replaceMap/productsDetailsAssociatedTwo.ts
@@ -30,6 +30,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -145,7 +150,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsDetailsProductsOne.ts
+++ b/src/consts/replaceMap/productsDetailsProductsOne.ts
@@ -30,6 +30,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -145,7 +150,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsListing.ts
+++ b/src/consts/replaceMap/productsListing.ts
@@ -186,12 +186,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['srcset'],
-      },
-      {
-        selector: '.product .product__icon source',
-        canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',

--- a/src/consts/replaceMap/productsListingHotspot.ts
+++ b/src/consts/replaceMap/productsListingHotspot.ts
@@ -29,6 +29,11 @@ export default {
         replace: ['data-product-id'],
       },
       {
+        selector: '.product .product__addtobasket button',
+        canBeNull: true,
+        replace: ['data-product_id'],
+      },
+      {
         selector: '.product .product-add-to-bsk',
         canBeNull: true,
         replace: ['href'],
@@ -144,7 +149,7 @@ export default {
       {
         selector: '.product .product__icon source',
         canBeNull: true,
-        replace: ['data-srcset'],
+        replace: ['src', 'srcset', 'data-srcset'],
       },
       {
         selector: '.product .product__icon img',


### PR DESCRIPTION
Added:
- additional selector for one particular button type, used to add a product to the basket
- additional properties to replace when dealing with a `<source>` product icon
  - technically, both `src` and `srcset` can be present on a `source` element, each under different circumstances, so we need to cover both cases